### PR TITLE
Update runners to ubuntu-24.04 from deprecated ubuntu-20.04 label

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ env:
   NIXPKGS_ALLOW_UNFREE: 1
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: 'ubuntu-24.04'
     steps:
     - uses: actions/checkout@v2.4.0
     - uses: cachix/install-nix-action@v16
@@ -18,7 +18,7 @@ jobs:
         authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
     - run: nix shell -c make -e download lint test DEBUG=1
   build-apk:
-    runs-on: ubuntu-20.04
+    runs-on: 'ubuntu-24.04'
     steps:
     - uses: actions/checkout@v2.4.0
     - uses: cachix/install-nix-action@v16
@@ -35,7 +35,7 @@ jobs:
         name: apk
         path: ./out/flutter/nm_app/app/outputs/apk/release/*
   build-web:
-    runs-on: ubuntu-20.04
+    runs-on: 'ubuntu-24.04'
     steps:
     - uses: actions/checkout@v2.4.0
     - uses: cachix/install-nix-action@v16
@@ -54,7 +54,7 @@ jobs:
     needs:
     - test
     - build-web
-    runs-on: ubuntu-20.04
+    runs-on: 'ubuntu-24.04'
     steps:
     - uses: actions/checkout@v2.4.0
     - uses: actions/download-artifact@master


### PR DESCRIPTION
This is a LSC run by http://go/ghss to upgrade all depreacated ubuntu-20.04 runners to ubuntu-24.04.

On April 1, 2025, GitHub will stop supporting ubuntu-20.04 runners and workflows configured with this label will cease to run.  This PR is an attempt to save you work by doing the upgrade for you.

WARNING: We do not know if the updated label is compatiable with your workflow or not.

If you do not want to merge this PR, feel free to close it and deal with the problem yourselves.

More context and feedback: http://b/406537467
